### PR TITLE
Enable installing a specific version of RKE2

### DIFF
--- a/extra_vars.yml.example
+++ b/extra_vars.yml.example
@@ -40,6 +40,13 @@ deploy_sylva_core: false
 ##########################
 
 #
+# RKE2 channel to install a specific version of RKE2 server.
+# This is to ensure that the given RKE2 version is compatible with the latest
+# version of Rancher.
+#
+rke2_channel_version: v1.24
+
+#
 # *Your* github person access token, used to interact with github APIs
 # during provisioning of the Metal3 stack, if you are consistently running
 # into github API rate limiting problems.

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Deploy latest rancher helm chart
   shell: >
-    helm upgrade {{ rancher_release }} {{ rancher_helm_chart_ref }} --install --atomic --create-namespace --namespace {{ rancher_namespace }} --set installCRDs=true --set hostname={{ rancher_hostname }} --set bootstrapPassword={{ rancher_bootstrap_password }} --set replicas={{ rancher_replicas }} --set extraEnv[0].name=CATTLE_SERVER_URL --set extraEnv[0].value=https://{{ rancher_hostname }} --set ingress.extraAnnotations.'external-dns\.alpha\.kubernetes\.io/target'={{ rancher_host_ip }} --set global.cattle.psp.enabled=false
+    helm upgrade {{ rancher_release }} {{ rancher_helm_chart_ref }} --install --atomic --create-namespace --namespace {{ rancher_namespace }} --set installCRDs=true --set hostname={{ rancher_hostname }} --set bootstrapPassword={{ rancher_bootstrap_password }} --set replicas={{ rancher_replicas }} --set extraEnv[0].name=CATTLE_SERVER_URL --set extraEnv[0].value=https://{{ rancher_hostname }} --set ingress.extraAnnotations.'external-dns\.alpha\.kubernetes\.io/target'={{ rancher_host_ip }}
   register: rancher_deploy_result
   until: rancher_deploy_result.rc == 0
   retries: 3

--- a/roles/rke2-server/defaults/main.yml
+++ b/roles/rke2-server/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
 # see https://docs.rke2.io/install/quickstart/
 rke2_installer_url: https://get.rke2.io
+
+# rke2 channel version to install
+# see https://update.rke2.io/v1-release/channels for a complete list
+#
+# i.e. 'v1.24'
+rke2_channel_version: v1.24

--- a/roles/rke2-server/tasks/main.yml
+++ b/roles/rke2-server/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Install RKE2
   shell: >
-    sudo /tmp/rke2_installer.sh
+    sudo INSTALL_RKE2_CHANNEL={{ rke2_channel_version }} /tmp/rke2_installer.sh
 
 - name: Enable and start rke2-server.service
   become: yes


### PR DESCRIPTION
Make RKE2 server version configurable so we can pin a version that is most compatible with the given version of Rancher.