### PR TITLE
Fix missing capi_core_version problem

### DIFF
--- a/playbooks/setup_metal3_core.yml
+++ b/playbooks/setup_metal3_core.yml
@@ -31,6 +31,7 @@
 
     - name: Define metal3-core node
       ansible.builtin.add_host:
+        ansible_python_interpreter: "{{ vm_python_interpreter | default('/usr/bin/python3') }}"
         name: metal3-core
         hostname: metal3-core
         ansible_user: "{{ vm_user }}"

--- a/playbooks/setup_metal3_network_infra.yml
+++ b/playbooks/setup_metal3_network_infra.yml
@@ -29,6 +29,7 @@
 
     - name: Define metal3-network-infra node
       ansible.builtin.add_host:
+        ansible_python_interpreter: "{{ vm_python_interpreter | default('/usr/bin/python3') }}"
         name: metal3-network-infra
         hostname: metal3-network-infra
         ansible_user: "{{ vm_user }}"

--- a/roles/baremetal/tasks/checkout_baremetal_repo.yml
+++ b/roles/baremetal/tasks/checkout_baremetal_repo.yml
@@ -1,0 +1,8 @@
+---
+- name: Checkout baremetal repo
+  include_tasks: checkout_repo.yml
+  vars:
+    repo_dir: baremetal
+    repo_url: "{{ baremetal_repo_url }}"
+    repo_branch: "{{ baremetal_branch }}"
+    repo_pull_request: "{{ baremetal_pull_request | default('') }}"

--- a/roles/kubernetes-tools/defaults/main.yml
+++ b/roles/kubernetes-tools/defaults/main.yml
@@ -6,3 +6,10 @@ kustomize_version: v5.0.1
 helm_download_archive: https://get.helm.sh/helm-{{ helm_version }}-linux-amd64.tar.gz
 k9s_download_archive: https://github.com/derailed/k9s/releases/download/{{ k9s_version }}/k9s_Linux_amd64.tar.gz
 kustomize_download_archive: https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F{{ kustomize_version }}/kustomize_{{ kustomize_version }}_linux_amd64.tar.gz
+
+# CAPI release version
+#
+# See https://github.com/kubernetes-sigs/cluster-api/releases
+#
+# NOTE: please include the 'v' prefix as it affects the URLs we are using.
+capi_core_version: v1.3.5


### PR DESCRIPTION
This PR also add default python intrepreter for the VMs in case the host has older version of Python which may not be in sync with the one from the VM.