### PR TITLE
Update python3 alternatives

### DIFF
--- a/roles/ironicclient/tasks/_suse.yml
+++ b/roles/ironicclient/tasks/_suse.yml
@@ -13,3 +13,11 @@
     path: /usr/bin/python3.10
     priority: 1
     link: /usr/bin/python
+
+- name: Select python3 althernative
+  become: yes
+  community.general.alternatives:
+    name: python3
+    path: /usr/bin/python3.10
+    priority: 1
+    link: /usr/bin/python3

--- a/roles/kubernetes-tools/tasks/_suse.yml
+++ b/roles/kubernetes-tools/tasks/_suse.yml
@@ -14,6 +14,14 @@
     priority: 1
     link: /usr/bin/python
 
+- name: Select python3 althernative
+  become: yes
+  community.general.alternatives:
+    name: python3
+    path: /usr/bin/python3.10
+    priority: 1
+    link: /usr/bin/python3
+
 - name: Add snappy repo
   include_role:
     name: vm

--- a/roles/vm/tasks/install_suse_package.yml
+++ b/roles/vm/tasks/install_suse_package.yml
@@ -8,4 +8,4 @@
   register: install_suse_packages_result
   until: "'rc' not in install_suse_packages_result or install_suse_packages_result.rc == 0"
   retries: 10
-  delay: 30
+  delay: 60


### PR DESCRIPTION
So it's consistent for both python and python3 to use python3.10.

Also increase the timeout for zypper so it will fail less often in updates.