### PR TITLE
Added libvirt network configurations needed for a libvirt deployment

### DIFF
--- a/libvirt/egress.xml
+++ b/libvirt/egress.xml
@@ -1,0 +1,15 @@
+<network>
+  <name>egress</name>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='m3-egress' stp='on' delay='0'/>
+  <ip address='192.168.125.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.125.2' end='192.168.125.254'/>
+    </dhcp>
+  </ip>
+</network>
+

--- a/libvirt/provisioning.xml
+++ b/libvirt/provisioning.xml
@@ -1,0 +1,15 @@
+<network>
+  <name>provisioning</name>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='m3-prov' stp='on' delay='0'/>
+  <ip address='192.168.124.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.124.2' end='192.168.124.254'/>
+    </dhcp>
+  </ip>
+</network>
+


### PR DESCRIPTION
There needs to be additions to extra_vars to use the networks, but for now these are libvirt networks that will be used to separate the egress and provisioning networks.