### PR TITLE
Add support for OpenSUSE Leap 15.5 hypervisor

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -13,7 +13,7 @@ source /etc/os-release
 export DISTRO="${ID}${VERSION_ID%.*}"
 export OS="${ID}"
 export OS_VERSION_ID="${VERSION_ID}"
-export SUPPORTED_DISTROS=(ubuntu22)
+export SUPPORTED_DISTROS=(ubuntu22 opensuse-leap15)
 
 if [[ ! "${SUPPORTED_DISTROS[*]}" =~ ${DISTRO} ]]; then
   echo "Supported OS distros for the host are: Ubuntu 22.04"
@@ -32,6 +32,10 @@ if [[ "${OS}" = "ubuntu" ]]; then
   if [[ "${DISTRO}" = "ubuntu22" ]]; then
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
   fi
+elif [[ "${OS}" = "opensuse-leap" ]]; then
+  sudo zypper -n update
+  sudo zypper -n install python311 python311-pip jq curl wget pkg-config bash-completion
+  sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
 fi
 
 sudo python -m pip install ansible

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ controlplane and worker host will be created)
 # Prerequisites <a name="prerequisites" />
 
 * Requires host with at least 32GB RAM & 200GB free disk space.
-* Should be run on a baremetal, nested virt may work but is not tested/supported.
+* Either [OpenSuse Leap 15.5](https://get.opensuse.org/leap/15.5/) or Ubuntu 22.04
+* Should be run on baremetal, nested virt may also work but is not tested/supported.
 
 # How To Setup Metal3 Demo Environment <a name="how_to_setup_metal3_demo" />
 - Refer to the [Metal3 Setup Doc](./docs/setup/metal3-setup.md) for a walkthrough of the Metal3 Demo environment setup.

--- a/docs/setup/metal3-setup.md
+++ b/docs/setup/metal3-setup.md
@@ -7,7 +7,10 @@ the Kubernetes native API. (see https://metal3.io/)
 
 ### Pre-requisite Dependencies
 
-Currently requires an Ubuntu (22.04 LTS) host to enable testing on Equinix.
+Currently requires one of the following OS choices:
+
+- [OpenSuse Leap 15.5](https://get.opensuse.org/leap/15.5/)
+- Ubuntu (22.04 LTS) (to enable testing on Equinix)
 
 1. Create a non-root user with sudo access
 
@@ -74,3 +77,4 @@ worker-0         available              true             9m44s
 - You can interact with Ironic directly on the metal3-core VM for debugging e.g `ssh metal@192.168.125.99 baremetal node list`
 - For more information about the BareMetalHost resource states refer to the [Metal3 documentation](https://github.com/metal3-io/baremetal-operator/blob/main/docs/BaremetalHost_ProvisioningState.png)
 - If a BareMetalHost resource is stuck in the inspecting state, `virsh console` can be useful to view the inspection ramdisk output
+- Note that you may need to `export LIBVIRT_DEFAULT_URI="qemu:///system"` to access the VMs via `virsh` as a non-root user

--- a/roles/libvirt-setup/templates/baremetalvm.xml.j2
+++ b/roles/libvirt-setup/templates/baremetalvm.xml.j2
@@ -5,7 +5,9 @@
 
   <os firmware='{{libvirt_firmware}}'>
     <type arch='{{ libvirt_arch }}' machine='q35'>hvm</type>
+{# FIXME - this fails validation with the libvirt version in Leap 15.5
     <loader secure='{{ 'yes' if libvirt_secure_boot else 'no' }}'/>
+#}
     <firmware>
 {% if libvirt_secure_boot %}
       <feature enabled='yes' name='secure-boot'/>

--- a/roles/packages_installation/defaults/main.yml
+++ b/roles/packages_installation/defaults/main.yml
@@ -17,5 +17,28 @@ packages:
     - python3-lxml
     - python3-netaddr
     - python3-passlib
+  opensuse:
+    - git
+    - libvirt-client
+    - qemu-kvm
+    - libvirt
+    - python311-pip
+    - python311-devel
+    - pkg-config
+    - gcc
+    - libvirt-devel
+    - mkisofs
+    - qemu
+    - virt-install
+    - sshpass
+    - libguestfs
+    - podman
+    - python311-lxml
+    - python311-netaddr
+    - python311-passlib
   pip3:
     - libvirt-python
+
+repos:
+  opensuse:
+    - "https://download.opensuse.org/repositories/devel:/languages:/python:/backports/15.5/devel:languages:python:backports.repo"

--- a/roles/packages_installation/tasks/main.yml
+++ b/roles/packages_installation/tasks/main.yml
@@ -1,5 +1,5 @@
 - block:
-  - name: Add a repos on openSUSE
+  - name: Add repos on openSUSE
     community.general.zypper_repository:
       repo: "{{ item }}"
       auto_import_keys: true

--- a/roles/packages_installation/tasks/main.yml
+++ b/roles/packages_installation/tasks/main.yml
@@ -1,13 +1,17 @@
-- name: Install packages
-  block:
-    - name: Install required packages on Ubuntu
-      package:
-        name: "{{ packages.ubuntu}}"
-        state: present
-      become: yes
-  when: ansible_facts['distribution'] == "Ubuntu"
-- name: Install pip packages
-  pip:
-    executable: "pip3"
-    name: "{{ packages.pip3 }}"
-    state: present
+- block:
+  - name: Add a repos on openSUSE
+    community.general.zypper_repository:
+      repo: "{{ item }}"
+      auto_import_keys: true
+    when: ansible_facts['distribution'] == 'openSUSE Leap'
+    loop: "{{ repos.opensuse }}"
+  - name: Install required packages on {{ ansible_facts['distribution'] }}
+    package:
+      name: "{{ packages.ubuntu if ansible_facts['distribution'] == 'Ubuntu' else packages.opensuse }}"
+      state: present
+  - name: Install pip packages
+    pip:
+      executable: "pip3"
+      name: "{{ packages.pip3 }}"
+      state: present
+  become: true


### PR DESCRIPTION
Currently we only support Ubuntu as it's convenient for testing on Equinix, but in lab environments it's preferable to test with Leap instead

Note this temporarily disables support for secure boot - the libvirt firmware auto-selection has different validation behaviour between the libvirt versions on Ubuntu and Leap so I need to figure out syntax which will work for both - regular UEFI deployments should still work fine in the meantime