### PR TITLE
SLEMicro: set provider/node ID from metadata

### DIFF
--- a/docs/example-manifests/SLEMicro/dhcp/rke2-agent.yaml
+++ b/docs/example-manifests/SLEMicro/dhcp/rke2-agent.yaml
@@ -42,7 +42,29 @@ spec:
         version: v1.25.3+rke2r1
         kubelet:
           extraArgs:
-            - provider-id=metal3://00112233-4455-6677-8899-aabbccddeeff   # this is a default uuid value you can modify it
+            - provider-id=metal3://BAREMETALHOST_UUID
+        additionalUserData:
+          config: |
+            variant: fcos
+            version: 1.4.0
+            systemd:
+              units:
+                - name: rke2-preinstall.service
+                  enabled: true
+                  contents: |
+                    [Unit]
+                    Description=rke2-preinstall
+                    Wants=network-online.target
+                    Before=rke2-install.service
+                    ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+                    [Service]
+                    Type=oneshot
+                    User=root
+                    ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+                    ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                    ExecStartPost=/bin/sh -c "umount /mnt"
+                    [Install]
+                    WantedBy=multi-user.target
         nodeName: "Node-sample2-cluster"  # this is a default NodeName value you can modify it
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/docs/example-manifests/SLEMicro/dhcp/rke2-control-plane.yaml
+++ b/docs/example-manifests/SLEMicro/dhcp/rke2-control-plane.yaml
@@ -46,7 +46,29 @@ spec:
     format: ignition
     kubelet:
       extraArgs:
-        - provider-id=metal3://00112233-4455-6677-8899-aabbccddeeff   # this is a default uuid value you can modify it
+        - provider-id=metal3://BAREMETALHOST_UUID
+    additionalUserData:
+      config: |
+        variant: fcos
+        version: 1.4.0
+        systemd:
+          units:
+            - name: rke2-preinstall.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=rke2-preinstall
+                Wants=network-online.target
+                Before=rke2-install.service
+                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+                [Service]
+                Type=oneshot
+                User=root
+                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                ExecStartPost=/bin/sh -c "umount /mnt"
+                [Install]
+                WantedBy=multi-user.target
     version: v1.25.3+rke2r1 # Has to be the compatible with the management cluster
     nodeName: "Node-sample2-cluster"  # this is a default NodeName value you can modify it
 ---

--- a/docs/setup/metal3-setup.md
+++ b/docs/setup/metal3-setup.md
@@ -35,7 +35,7 @@ cd metal3-demo
 ./01_prepare_host.sh
 ```
 
-## Deploying the SUSE Edge Metal<sup>3</sup> Demo
+## Configure the host environment
 
 1. (optional) customize extra_vars.yml
 
@@ -49,28 +49,37 @@ If desired the defaults from `extra_vars.yml` can be customized, copy the file a
   ./02_configure_host.sh
   ```
 
-- If you want to use your custom image (for instance the SLE Micro 5.5), you can export the variable `OS_LOCAL_IMAGE` with the path to your image:
+Note this configures the environment to deploy downstream clusters with openSUSE Leap, for SLEMicro follow the additional steps below.
 
-1. Download the SLE Micro image from the [SUSE Customer Center](https://www.suse.com/download/sle-micro/). The current version supported is the 5.5 in raw format. 
+### Enable deploying with SLEMicro
 
-**Note** The file downloaded is a xz compressed file. It must be uncompressed before using it as a valid image. 
+If you want to use SLEMicro for downstream clusters then a few additional steps are required:
 
-2. Move the image downloaded into the local directory which will be defined in the environment var `OS_LOCAL_IMAGE`.
+1. Download the SLE Micro image from the [SUSE Customer Center](https://www.suse.com/download/sle-micro/). The version must be 5.5 in raw format.
 
-3. Execute the script to configure the host using the local image: 
+**Note** The file downloaded is a xz compressed file. It must be uncompressed before using it as a valid image.
+
+2. Move the image downloaded into the local directory which will be defined in the environment variable `OS_LOCAL_IMAGE`.
+
+3. Generate a registration code so we can install additional packages when customizing the downloaded image, this is defined in the environment variable `EIB_REGISTRATION_CODE`.
+
+4. Execute the script to configure the host using the local image:
 
   ```shell
   export OS_LOCAL_IMAGE=/path/to/image.raw
+  export EIB_REGISTRATION_CODE=<generated registration code>
   ./02_configure_host.sh
   ```
 
-4. Create management cluster
+## Deploy the management cluster and prepare hosts
+
+1. Create management cluster
 
   ```shell
   ./03_launch_mgmt_cluster.sh
   ```
 
-5. Apply the BareMetalHost manifests
+2. Apply the BareMetalHost manifests
 
 ```shell
 kubectl apply -f ~/metal3-demo-files/baremetalhosts

--- a/roles/edge-image-builder/defaults/main.yml
+++ b/roles/edge-image-builder/defaults/main.yml
@@ -4,3 +4,4 @@ eib_source_image_path: "{{ os_local_image | dirname }}"
 eib_output_image_name: SLE-Micro-eib-output.raw
 working_dir: "{{ lookup('env', 'HOME') }}/metal3-demo-files"
 eib_path: "{{ working_dir }}/eib"
+eib_registration_code: "{{ lookup('env', 'EIB_REGISTRATION_CODE') }}"

--- a/roles/edge-image-builder/tasks/main.yml
+++ b/roles/edge-image-builder/tasks/main.yml
@@ -35,7 +35,7 @@
         growpart "$parent_dev" "$partnum" || ret=$?
         [ $ret -eq 0 ] || [ $ret -eq 1 ] || exit 1
         /usr/lib/systemd/systemd-growfs "$mnt"
-      }  
+      }
       growfs /
 
 - name: Git checkout
@@ -44,11 +44,13 @@
     dest: "{{ working_dir }}/edge-image-builder"
 
 - name: build the EIB container image
+  become: true
   containers.podman.podman_image:
     name: eib:dev
     path: "{{ working_dir }}/edge-image-builder"
 
 - name: Run EIB container to generate the custom image
+  become: true
   containers.podman.podman_container:
     name: eib
     rm: true
@@ -58,6 +60,7 @@
     detach: false
     state: started
     force_restart: no
+    privileged: true
     command: "/bin/eib -config-file config-eib.yaml -config-dir /eib -build-dir /eib/_build"
 
 - name: Generate sha256sum for EIB image

--- a/roles/edge-image-builder/templates/config-eib.yaml.j2
+++ b/roles/edge-image-builder/templates/config-eib.yaml.j2
@@ -10,3 +10,7 @@ operatingSystem:
   users:
   - username: root
     encryptedPassword: "$6$Hq6XnrxLLviHzrkE$Qft13mh082uQZl6Wm09a7pUmf7ULt6vlr9u7koAV60v/LNs1YkseTSuBmr1SJ2yg.Ib2WY06YGldJbDGCC4ry1"
+  packages:
+    packageList:
+      - jq
+    registrationCode: "{{ eib_registration_code }}"


### PR DESCRIPTION
In the cloud-init case the BMH metadata is read automatically and can be used to populate the provider/node ID, but in the SLEMicro case we need to modify the configuration by reading the config-drive and updating the RKE2 configuration file.

With this fix we can see the placeholder is correctly replaced with the BMH uid:

```
kubectl get bmh -o json  controlplane-0 | jq .metadata.uid
"5bb5ea0b-78d4-4ff1-b45b-47503c146e72"

virsh console 4
Connected to domain 'controlplane_0'
Escape character is ^] (Ctrl + ])

controlplane-0:~ # cat /etc/rancher/rke2/config.yaml 
cluster-cidr: 192.168.0.0/18
kubelet-arg:
- provider-id=metal3://5bb5ea0b-78d4-4ff1-b45b-47503c146e72
...
```

/cc @alknopfler @ipetrov117 