### PR TITLE
Bump metal3 chart to 0.4.4

### DIFF
--- a/roles/metal3/defaults/main.yml
+++ b/roles/metal3/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 metal3_repo_url: https://github.com/suse-edge/charts.git
 metal3_branch: main
-metal3_chart_version: 0.4.0
+metal3_chart_version: 0.4.4
 metal3_namespace: metal3-system
 
 working_dir: "{{ lookup('env', 'HOME') }}/metal3-demo-files"


### PR DESCRIPTION
Updates to the latest version as introduced by https://github.com/suse-edge/charts/pull/83

/cc @Kristian-ZH 