### PR TITLE
Leap OS download checksum workaround

### DIFF
--- a/roles/image-cache/tasks/main.yml
+++ b/roles/image-cache/tasks/main.yml
@@ -32,7 +32,7 @@
     get_url:
       url: "{{ image_url }}"
       dest: "{{ images_dir }}/{{ image_name }}"
-      checksum: "{{ image_checksum }}"
+#      checksum: "{{ image_checksum }}"
 
   - name: Generate OS image checksum file
     shell: |


### PR DESCRIPTION
The 02 script sometimes fails like:

```
fatal: [localhost]: FAILED! => {"changed": true, "checksum_dest": null, "checksum_src": "7894086ab461d955bb355142564adb2f2b7760b6", "dest": "/var/lib/libvirt/images/image-cache/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2", "elapsed": 26, "msg": "The checksum for /var/lib/libvirt/images/image-cache/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2 did not match 951db5f6f6dc7cd6b7ca344c39606e436a18e9f27ee590e748acbb28b37fbd61; it was fa9441b625ef3aed8ffada4c2e7297d30dc31bd7c1b148063ee79d4f21964b8a.", "src": "/root/.ansible/tmp/ansible-moduletmp-1708000027.2406626-rdurbzfu/tmp65f65354", "url": "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2"}
```

Until we figure out how to resolve that mismatch lets remove the checksum so the download will always happen