### PR TITLE
Rename metal3-core to management-cluster

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -14,4 +14,4 @@ export ANSIBLE_ROLES_PATH=$PROJECT_DIR/roles
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -i ${PROJECT_DIR}/inventories/localhost_inventory.yml \
   -e "@${EXTRA_VARS_FILE}" \
-  $PROJECT_DIR/playbooks/setup_metal3_core.yml $@
+  $PROJECT_DIR/playbooks/setup_management_cluster.yml $@

--- a/docs/setup/metal3-setup.md
+++ b/docs/setup/metal3-setup.md
@@ -103,7 +103,7 @@ worker-0         available              true             9m44s
 ## Development Notes
 
 - You may pass `-vvv` at the end of the scripts to see more verbose output, or to pass arbitrary additional arguments to ansible-playbook
-- You can interact with Ironic directly on the metal3-core VM for debugging e.g `ssh metal@192.168.125.99 baremetal node list`
+- You can interact with Ironic directly on the management-cluster VM for debugging e.g `ssh metal@192.168.125.99 baremetal node list`
 - For more information about the BareMetalHost resource states refer to the [Metal3 documentation](https://github.com/metal3-io/baremetal-operator/blob/main/docs/BaremetalHost_ProvisioningState.png)
 - If a BareMetalHost resource is stuck in the inspecting state, `virsh console` can be useful to view the inspection ramdisk output
 - Note that you may need to `export LIBVIRT_DEFAULT_URI="qemu:///system"` to access the VMs via `virsh` as a non-root user

--- a/extra_vars.yml
+++ b/extra_vars.yml
@@ -28,16 +28,16 @@ egress_network_bridge_ip: "{{ egress_network_cidr_v4|ansible.utils.nthhost(1)|de
 #
 # Public IPs
 #
-metal3_core_public_ip: 192.168.125.99
-metal3_core_ironic_ip: 192.168.125.10
+management_cluster_public_ip: 192.168.125.99
+management_cluster_ironic_ip: 192.168.125.10
 
 
-metal3_core_vm_network:
+management_cluster_vm_network:
   version: 2
   ethernets:
     eth0:
       dhcp4: false
-      addresses: ["{{ metal3_core_public_ip }}/24"]
+      addresses: ["{{ management_cluster_public_ip }}/24"]
       nameservers:
         addresses: "{{ egress_network_bridge_ip }}"
       routes:

--- a/playbooks/setup_management_cluster.yml
+++ b/playbooks/setup_management_cluster.yml
@@ -9,29 +9,29 @@
       when:
         - (not do_not_install_vm | default(False)) | bool
       vars:
-        vm_hostname: metal3-core
-        vm_instance_name: metal3-core
-        vm_network: "{{ metal3_core_vm_network }}"
-        vm_public_network_ip: "{{ metal3_core_public_ip }}"
+        vm_hostname: management-cluster
+        vm_instance_name: management-cluster
+        vm_network: "{{ management_cluster_vm_network }}"
+        vm_public_network_ip: "{{ management_cluster_public_ip }}"
         vm_libvirt_network_params: "{{ metal3_vm_libvirt_network_params }}"
         vm_memory: 16384
         vm_vcpus: 8
 
-    - name: Show metal3-core vm IP
+    - name: Show management-cluster vm IP
       debug:
-        msg: "Login to the metal3-core vm with 'ssh {{ vm_user }}@{{ metal3_core_public_ip }}'"
+        msg: "Login to the management-cluster vm with 'ssh {{ vm_user }}@{{ management_cluster_public_ip }}'"
 
-    - name: Define metal3-core node
+    - name: Define management-cluster node
       ansible.builtin.add_host:
         ansible_python_interpreter: "{{ vm_python_interpreter | default('/usr/bin/python3') }}"
-        name: metal3-core
-        hostname: metal3-core
+        name: management-cluster
+        hostname: management-cluster
         ansible_user: "{{ vm_user }}"
-        ansible_host: "{{ metal3_core_public_ip }}"
+        ansible_host: "{{ management_cluster_public_ip }}"
         groups:
-          - "{{ metal3_corehost_group | default('metal3_core_group') }}"
+          - "{{ management_clusterhost_group | default('management_cluster_group') }}"
 
-- hosts: metal3-core
+- hosts: management-cluster
   tasks:
     - name: Deploy docker
       import_role:
@@ -56,7 +56,7 @@
       import_role:
         name: ironicclient
       vars:
-        public_ip: "{{ metal3_core_public_ip }}"
+        public_ip: "{{ management_cluster_public_ip }}"
 
 - hosts: localhost
   connection: local
@@ -65,7 +65,7 @@
       replace:
         path: ~/.kube/config
         regexp: '127\.0\.0\.1'
-        replace: "{{ metal3_core_public_ip }}"
+        replace: "{{ management_cluster_public_ip }}"
 
     - name: Deploy cert-manager
       import_role:
@@ -75,8 +75,8 @@
       import_role:
         name: rancher
       vars:
-        rancher_hostname: metal3-core
-        rancher_host_ip: "{{ metal3_core_public_ip }}"
+        rancher_hostname: management-cluster
+        rancher_host_ip: "{{ management_cluster_public_ip }}"
 
     - name: Deploy local-path-provisioner
       import_role:
@@ -86,7 +86,7 @@
       import_role:
         name: metallb
       vars:
-        metal3_core_ironic_ip: "{{ metal3_core_ironic_ip }}"
+        management_cluster_ironic_ip: "{{ management_cluster_ironic_ip }}"
 
     - name: Deploy capi
       import_role:

--- a/roles/metal3/templates/metal3-values.yaml.j2
+++ b/roles/metal3/templates/metal3-values.yaml.j2
@@ -1,5 +1,5 @@
 global:
-  ironicIP: {{ metal3_core_ironic_ip | default('192.168.125.10') }}
+  ironicIP: {{ management_cluster_ironic_ip | default('192.168.125.10') }}
 
 metal3-mariadb:
   persistence:

--- a/roles/metallb/templates/ip-address-pool.yaml.j2
+++ b/roles/metallb/templates/ip-address-pool.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ metallb_namespace }}
 spec:
   addresses:
-  - {{ metal3_core_ironic_ip }}/32
+  - {{ management_cluster_ironic_ip }}/32
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement


### PR DESCRIPTION
The current historical name is somewhat confusing so lets align the name with the usage elsewhere to describe the management-cluster where metal3 and other components are running