### PR TITLE
Update EIB, RKE2 and CAPI versions

### DIFF
--- a/roles/capi/defaults/main.yml
+++ b/roles/capi/defaults/main.yml
@@ -4,7 +4,7 @@
 # See https://github.com/kubernetes-sigs/cluster-api/releases
 #
 # NOTE: please include the 'v' prefix as it affects the URLs we are using.
-capi_core_version: v1.6.0
+capi_core_version: v1.6.2
 
 # CAPM3 release version
 #

--- a/roles/edge-image-builder/defaults/main.yml
+++ b/roles/edge-image-builder/defaults/main.yml
@@ -7,7 +7,7 @@ eib_path: "{{ working_dir }}/eib"
 eib_registration_code: "{{ lookup('env', 'EIB_REGISTRATION_CODE') }}"
 
 # If eib_git_version is specified we build a local image
-eib_container_image: "registry.opensuse.org/isv/suse/edge/edgeimagebuilder/containerfile/suse/edge-image-builder:1.0.0.rc1"
+eib_container_image: "registry.opensuse.org/isv/suse/edge/edgeimagebuilder/containerfile/suse/edge-image-builder:1.0.1"
 eib_git_version: ""
 
 libvirt_network_dhcp: true

--- a/roles/edge-image-builder/tasks/main.yml
+++ b/roles/edge-image-builder/tasks/main.yml
@@ -81,7 +81,7 @@
     state: started
     force_restart: no
     privileged: true
-    command: "build -config-file config-eib.yaml -config-dir /eib -build-dir /eib/_build"
+    command: "build --definition-file config-eib.yaml"
 
 - name: Generate sha256sum for EIB image
   become: true

--- a/roles/example-manifests/defaults/main.yml
+++ b/roles/example-manifests/defaults/main.yml
@@ -22,4 +22,4 @@ egress_network_bridge_ip: "{{ egress_network_cidr_v4|ansible.utils.nthhost(1)|de
 cluster_name: "sample-cluster"
 cluster_namespace: "default"
 
-cluster_rke2_version: "v1.28.3+rke2r1"
+cluster_rke2_version: "v1.28.8+rke2r1"

--- a/roles/kubernetes-tools/defaults/main.yml
+++ b/roles/kubernetes-tools/defaults/main.yml
@@ -8,7 +8,7 @@ k9s_download_archive: https://github.com/derailed/k9s/releases/download/{{ k9s_v
 kustomize_download_archive: https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F{{ kustomize_version }}/kustomize_{{ kustomize_version }}_linux_amd64.tar.gz
 kubetail_download_url: https://raw.githubusercontent.com/johanhaleby/kubetail/master/kubetail
 
-kubectl_version: v1.28.4
+kubectl_version: v1.28.8
 kubectl_download_url: https://cdn.dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl
 
 # CAPI release version

--- a/roles/kubernetes-tools/defaults/main.yml
+++ b/roles/kubernetes-tools/defaults/main.yml
@@ -16,4 +16,4 @@ kubectl_download_url: https://cdn.dl.k8s.io/release/{{ kubectl_version }}/bin/li
 # See https://github.com/kubernetes-sigs/cluster-api/releases
 #
 # NOTE: please include the 'v' prefix as it affects the URLs we are using.
-capi_core_version: v1.6.0
+capi_core_version: v1.6.2


### PR DESCRIPTION
This aligns the version with our latest targets, and also fixes the issue that the current EIB image tag has been removed, so we can't use the rc1 version anymore.