### PR TITLE
Additional version updates

### DIFF
--- a/roles/metal3/defaults/main.yml
+++ b/roles/metal3/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 metal3_repo_url: https://github.com/suse-edge/charts.git
 metal3_branch: main
-metal3_chart_version: 0.6.1
+metal3_chart_version: 0.6.5
 metal3_namespace: metal3-system
 
 working_dir: "{{ lookup('env', 'HOME') }}/metal3-demo-files"

--- a/roles/rancher/defaults/main.yml
+++ b/roles/rancher/defaults/main.yml
@@ -2,6 +2,7 @@
 rancher_helm_repo_url: https://releases.rancher.com/server-charts/stable
 rancher_helm_repo_name: rancher-stable
 rancher_helm_chart_ref: rancher-stable/rancher
+rancher_version: 2.8.3
 
 rancher_release: rancher
 rancher_replicas: 3

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -9,10 +9,11 @@
     repo_url: "{{ rancher_helm_repo_url }}"
     name: "{{ rancher_helm_repo_name }}"
 
-- name: Deploy latest Rancher Helm chart
+- name: Deploy Rancher Helm chart
   kubernetes.core.helm:
     name: "{{ rancher_release }}"
     chart_ref: "{{ rancher_helm_chart_ref }}"
+    chart_version: "{{ rancher_version }}"
     state: present
     release_namespace: "{{ rancher_namespace }}"
     values:

--- a/roles/rke2-server/defaults/main.yml
+++ b/roles/rke2-server/defaults/main.yml
@@ -2,8 +2,5 @@
 # see https://docs.rke2.io/install/quickstart/
 rke2_installer_url: https://get.rke2.io
 
-# rke2 channel version to install
-# see https://update.rke2.io/v1-release/channels for a complete list
-#
-# i.e. 'v1.24'
-rke2_channel_version: v1.27
+# rke2 version to install
+cluster_rke2_version: "v1.28.8+rke2r1"

--- a/roles/rke2-server/tasks/main.yml
+++ b/roles/rke2-server/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Install RKE2
   shell: >
-    sudo INSTALL_RKE2_CHANNEL={{ rke2_channel_version }} /tmp/rke2_installer.sh
+    sudo INSTALL_RKE2_VERSION={{ cluster_rke2_version }} /tmp/rke2_installer.sh
 
 - name: Enable and start rke2-server.service
   become: yes


### PR DESCRIPTION
Follow-up to #52 because I missed that the management cluster RKE2+Rancher version needs updating, and also the Metal3 chart version.