### PR TITLE
Add mode to EIB custom script

### DIFF
--- a/roles/edge-image-builder/tasks/main.yml
+++ b/roles/edge-image-builder/tasks/main.yml
@@ -22,6 +22,7 @@
 - name: Copy file into the eib custom scripts directory (fix growfs issue)
   copy:
     dest: "{{ eib_path }}/custom/scripts/fix-growfs.sh"
+    mode: 0755
     content: |
       #!/bin/bash
       growfs() {


### PR DESCRIPTION
Since the EIB update in #52 this is required because of https://github.com/suse-edge/edge-image-builder/pull/305