### PR TITLE
Update Metal3 chart to 0.7.3

### DIFF
--- a/roles/edge-image-builder/defaults/main.yml
+++ b/roles/edge-image-builder/defaults/main.yml
@@ -14,7 +14,7 @@ eib_source_image_slemicro: "{{ True if eib_source_image_name.startswith('SLE-Mic
 eib_registration_code: "{{ lookup('env', 'EIB_REGISTRATION_CODE') }}"
 
 # If eib_git_version is specified we build a local image
-eib_container_image: "registry.opensuse.org/isv/suse/edge/edgeimagebuilder/containerfile/suse/edge-image-builder:1.0.1"
+eib_container_image: "registry.opensuse.org/isv/suse/edge/edgeimagebuilder/containerfile/suse/edge-image-builder:1.0.2"
 eib_git_version: ""
 
 libvirt_network_dhcp: true

--- a/roles/edge-image-builder/files/configure-network.sh
+++ b/roles/edge-image-builder/files/configure-network.sh
@@ -23,9 +23,10 @@ fi
 
 # FIXME: we can probably improve this, but there's no jq in the ramdisk
 DESIRED_HOSTNAME=$(cat /mnt/openstack/latest/meta_data.json | tr ',{}' '\n' | grep '\"metal3-name\"' | sed 's/.*\"metal3-name\": \"\(.*\)\"/\1/')
+echo "${DESIRED_HOSTNAME}" > /etc/hostname
 
 mkdir -p /tmp/nmc/{desired,generated}
-cp ${NETWORK_DATA_FILE} /tmp/nmc/desired/${DESIRED_HOSTNAME}.yaml
+cp ${NETWORK_DATA_FILE} /tmp/nmc/desired/_all.yaml
 umount /mnt
 
 ./nmc generate --config-dir /tmp/nmc/desired --output-dir /tmp/nmc/generated

--- a/roles/libvirt-setup/templates/baremetalhost.yaml.j2
+++ b/roles/libvirt-setup/templates/baremetalhost.yaml.j2
@@ -36,7 +36,6 @@ stringData:
     - name: enp1s0
       type: ethernet
       state: up
-      mac-address: "{{ node_mac_map.get(item.name).get(libvirt_networks[0].name) }}"
       ipv4:
         address:
         - ip:  "{{ node_ip_map.get(item.name).get(libvirt_networks[0].name) }}"

--- a/roles/metal3/defaults/main.yml
+++ b/roles/metal3/defaults/main.yml
@@ -2,7 +2,7 @@
 metal3_repo_url: https://github.com/suse-edge/charts.git
 metal3_branch: main
 
-metal3_chart_version: 0.7.2
+metal3_chart_version: 0.7.3
 metal3_namespace: metal3-system
 
 working_dir: "{{ lookup('env', 'HOME') }}/metal3-demo-files"


### PR DESCRIPTION
This enables us to use the nmc 0.3.0 unified config option which removes the constraint that a mac-address must be provided