### PR TITLE
Update to Leap 15.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ controlplane and worker host will be created)
 # Prerequisites <a name="prerequisites" />
 
 * Requires host with at least 32GB RAM & 200GB free disk space.
-* Either [OpenSuse Leap 15.5](https://get.opensuse.org/leap/15.5/) or Ubuntu 22.04
+* Either [OpenSuse Leap 15.6](https://get.opensuse.org/leap/15.6/) or Ubuntu 22.04
 * Should be run on baremetal, nested virt may also work but is not tested/supported.
 
 # How To Setup Metal3 Demo Environment <a name="how_to_setup_metal3_demo" />

--- a/docs/setup/metal3-setup.md
+++ b/docs/setup/metal3-setup.md
@@ -61,14 +61,14 @@ Command-line flags may be passed to Ansible via the script, for example to disab
   ./03_build_images.sh
   ```
 
-Note this configures the environment to deploy management and downstream clusters with [openSUSE Leap Micro 5.5](https://get.opensuse.org/leapmicro/5.5/),
-for [SLEMicro 5.5](https://documentation.suse.com/sle-micro/5.5/) follow the additional steps below.
+Note this configures the environment to deploy management and downstream clusters with [openSUSE Leap Micro 6.0](https://get.opensuse.org/leapmicro/6.0/),
+for [SLMicro 6.0](https://documentation.suse.com/sle-micro/6.0/) follow the additional steps below.
 
 ### Enable deploying with SLEMicro
 
 If you want to use SLEMicro then a few additional steps are required:
 
-1. Download the SLE Micro image from the [SUSE Customer Center](https://www.suse.com/download/sle-micro/). The version must be 5.5 in raw format.
+1. Download the SLE Micro image from the [SUSE Customer Center](https://www.suse.com/download/sle-micro/). The version must be 6.0 in raw format.
 
 **Note** The file downloaded is a xz compressed file. It must be uncompressed before using it as a valid image.
 

--- a/docs/setup/metal3-setup.md
+++ b/docs/setup/metal3-setup.md
@@ -9,7 +9,7 @@ the Kubernetes native API. (see https://metal3.io/)
 
 Currently requires one of the following OS choices:
 
-- [OpenSuse Leap 15.5](https://get.opensuse.org/leap/15.5/)
+- [OpenSuse Leap 15.6](https://get.opensuse.org/leap/15.6/)
 - Ubuntu (22.04 LTS) (to enable testing on Equinix)
 
 1. Create a non-root user with sudo access

--- a/roles/libvirt-setup/templates/baremetalvm.xml.j2
+++ b/roles/libvirt-setup/templates/baremetalvm.xml.j2
@@ -5,9 +5,6 @@
 
   <os firmware='{{libvirt_firmware}}'>
     <type arch='{{ libvirt_arch }}' machine='q35'>hvm</type>
-{# FIXME - this fails validation with the libvirt version in Leap 15.5
-    <loader secure='{{ 'yes' if libvirt_secure_boot else 'no' }}'/>
-#}
     <firmware>
 {% if libvirt_secure_boot %}
       <feature enabled='yes' name='secure-boot'/>

--- a/roles/packages_installation/defaults/main.yml
+++ b/roles/packages_installation/defaults/main.yml
@@ -42,4 +42,4 @@ packages:
 
 repos:
   opensuse:
-    - "https://download.opensuse.org/repositories/devel:/languages:/python:/backports/15.5/devel:languages:python:backports.repo"
+    - "https://download.opensuse.org/repositories/devel:/languages:/python:/backports/15.6/devel:languages:python:backports.repo"


### PR DESCRIPTION
15.5 is nearly EOL so update to 15.6
    
Note the libvirt secureboot loader can be removed ref https://libvirt.org/kbase/secureboot.html as the 15.6 libvirt version is newer than 8.6.0 (10.0.0)

Also update Leap/SLEMicro references to 6.0  - this was missed in #58


