### PR TITLE
Adding a timeout parameter to the 'Wait for VM to be up and running Kubernetes' task for the  management cluster

### DIFF
--- a/roles/management-cluster/defaults/main.yml
+++ b/roles/management-cluster/defaults/main.yml
@@ -12,3 +12,6 @@ disk_image_file: "{{ libvirt_images_dir }}/{{ image_os_name }}-{{ vm_instance_na
 
 # size of the disk image
 disk_image_size: 40G
+
+# Timeout for task "Wait for VM to be up and running Kubernetes", increase in case of older hardware
+timeout_vm_k8s: 600

--- a/roles/management-cluster/tasks/main.yml
+++ b/roles/management-cluster/tasks/main.yml
@@ -75,3 +75,4 @@
     host: "{{ vm_public_network_ip }}"
     port: 6443
     delay: 60
+    timeout: 3600 # Adding a timeout to allow deployment on machines with slower disks

--- a/roles/management-cluster/tasks/main.yml
+++ b/roles/management-cluster/tasks/main.yml
@@ -75,4 +75,4 @@
     host: "{{ vm_public_network_ip }}"
     port: 6443
     delay: 60
-    timeout: 3600 # Adding a timeout to allow deployment on machines with slower disks
+    timeout: {{ timeout_vm_k8s }}


### PR DESCRIPTION
Adding a timeout parameter to the 'Wait for VM to be up and running Kubernetes' task for the  management cluster